### PR TITLE
vyatta-op-dhcp-server: Bugs #121 and #160

### DIFF
--- a/lib/DHCPServerOpMode.pm
+++ b/lib/DHCPServerOpMode.pm
@@ -209,7 +209,12 @@ sub parse_lease {
 
     # Get client name
     my ($client_name) = $lease =~ /client-hostname \s+ "* (.*?) "* \s* ;/sx;
-    $client_name = "" unless defined($client_name);
+    if (defined($client_name)) {
+        my $prefix = $pool."_";
+        $client_name =~ s/$prefix//;
+    } else {
+        $client_name = "";
+    }
     $lease_hash{"hostname"} = $client_name;
 
     return %lease_hash;


### PR DESCRIPTION
 vyatta-op-dhcp-server: update dhcp lease parsing logic based on type

Update the parsing logic for DHCP leases, so it allows certain lease
entries to be missing in /config/dhcpd.leases for backup and free
leases, but ensuring that they are present in active ones.

Bug #121 http://bugzilla.vyos.net/show_bug.cgi?id=121
