### PR TITLE
T726: read the set option on commit to check pool usage

### DIFF
--- a/lib/DHCPServerOpMode.pm
+++ b/lib/DHCPServerOpMode.pm
@@ -63,9 +63,16 @@ sub get_active {
             $ip = $1;
         }
         next if (!defined($ip));
-        if ($line =~ /shared-network:\s(.*)/) {
-            $pool = $1;
-        }
+        #if ($line =~ /shared-network:\s(.*)/) {
+        #    $pool = $1;
+        #}
+	if ($line =~ /set shared-networkname =\s(.*)/) {
+		my $a = $1;
+		$a =~ s/[\";]+//g;
+		$pool = $a
+	}
+	
+	# set shared-networkname = "TEST";
         next if (!defined($pool));
         if (!defined($active_hash{"$pool"}->{"$ip"})){
             $active_hash{"$pool"}->{"$ip"} = 0;


### PR DESCRIPTION
sets the shared network pool name again, however I had to use a different key word, shared-network itself is a reserved keyword.